### PR TITLE
Update geninv.sh

### DIFF
--- a/ansible/geninv.sh
+++ b/ansible/geninv.sh
@@ -26,6 +26,9 @@ declare -A groups
 while read type x hosts; do
     readarray -d, -t ips < <(printf "${hosts}")
 
+    # If the host list is empty don't added it to the inventory file
+    [[ "${hosts}" == "\"\"" ]] && continue
+    
     if [[ "${type}" == *-* ]]; then
         groups[${type%%-*}]+=" ${type#*-} "
     fi


### PR DESCRIPTION
terraform changed its output to return an empty string if no host was deployed. This caused the Ansible to try to connect to a VM that was not there