### PR TITLE
Update genconf.sh

### DIFF
--- a/ssh/genconf.sh
+++ b/ssh/genconf.sh
@@ -40,6 +40,11 @@ while read type x hosts; do
     [ -z "${hosts}" ] && continue
 
     readarray -d, -t ips < <(printf "${hosts}")
+    
+    # Don't add a host if the hostlist is empty
+    [[ "${hosts}" == "\"\"" ]] && continue
+    # Remove any quotes around the hostnames
+    hosts=`echo $hosts | sed -s "s/^\(\(\"\(.*\)\"\)\|\('\(.*\)'\)\)\$/\\3\\5/g"`
 
     for i in "${!ips[@]}"; do
         printf "Host %s-%02d\n" "${type}" "${i}"


### PR DESCRIPTION
Remove quotes around the hostname output from terraform. The is to support newer versions of terraform that have added quotes around the name or an empty string