### PR TITLE
Update efa_installer_version

### DIFF
--- a/ansible/vars/fabric.yml
+++ b/ansible/vars/fabric.yml
@@ -15,4 +15,4 @@
 ---
 mofed_package_version: "5.6-2.0.9.0"
 
-efa_installer_version: "1.14.1"
+efa_installer_version: "1.21.0"


### PR DESCRIPTION
Notable changes between installer version 1.14.1 and 1.21.0:


```
[1.21.0] - December 2022
- Add support for Rocky Linux 9 OS
- Ingest efa driver 2.1.1
- Ingest libfabric 1.16.1amzn3.0
- Upgrade efa-config package to 1.12

[1.20.0] - November 2022
- Add support for Rocky Linux 8 OS.
- Ingest efa driver 2.1.0.
- Ingest rdma-core 43.0.
- Ingest libfabric 1.16.1amzn1.0

[1.19.0] - October 2022
- Ingest libfabric 1.16.0
- Build Open MPI with `--enable-orterun-prefix-by-default`

[1.18.0] - August 2022
- Add support for Ubuntu22.04

[1.17.3] - August 2022
- Update libfabric to 1.16.0~amzn4.0. The "~" indicates it is a pre-release version of libfabric 1.16.0.
- Extend post-installation pingpong test timeout to 20 seconds

[1.17.2] - July 2022
- Update libfabric to 1.16.0~amzn3.0. The "~" indicates it is a pre-release version of libfabric 1.16.0.

[1.17.1] - July 2022
- Update libfabric to 1.16.0~amzn2.0. The "~" indicates it is a pre-release version of libfabric 1.16.0.
- Disable the experimental net provider when building libfabric

[1.17.0] - July 2022
- Update rdma-core to v41.0
- Update Open MPI to 4.1.4
- Update libfabric to 1.16.0~amzn1.0. The "~" indicates it is a pre-release version of libfabric 1.16.0.

[1.16.0] - June 2022
- Update libfabric to 1.15.1amzn1.0, contains neuron library name change
- Upgrade efa-config to 1.10
- Exclude opx and rxd providers in the libfabric build

[1.15.2] - May 2022
- Update libfabric to 1.14.1

[1.15.1] - March 2022
- Update libfabric to 1.14.0amzn1.0

[1.15.0] - Feburary 2022
- Fix a bug that cause installation fail on Open SuSE 15.3
- Drop support of Open SuSE 15.2 (as Open SuSE 15.2 reached end of life)
- Drop Support of CentOS 8 (as CentOS 8 reached end of life)
- Update libfabric to 1.14.0
- Update efa kernel driver to 1.16.0
- Update rdma-core to v39.0
- Update Open MPI to version 4.1.2.
```