### PR TITLE
bump enroot version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ sudo apt update -y
 arch=$(dpkg --print-architecture)
 echo $arch
 
-curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.0/enroot_3.4.0-1_${arch}.deb
-curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.0/enroot+caps_3.4.0-1_${arch}.deb
+curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot_3.4.1-1_${arch}.deb
+curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot+caps_3.4.1-1_${arch}.deb
 sudo apt install -y ./*.deb
 rm enroot*
 ```


### PR DESCRIPTION
I know it is technically in pre-release but the enroot version needs to be bumped or Nephele init fails due to the new format.