### PR TITLE
Fix Ansible EFA IP Problem

### DIFF
--- a/ansible/roles/efa/tasks/ubuntu.yml
+++ b/ansible/roles/efa/tasks/ubuntu.yml
@@ -53,7 +53,7 @@
                    - from: {{ vars.ansible_facts[iface].ipv4.address }}
                      table: 10{{ loop.index }}
                   routes:
-                   - to: {{ network | ansible.netcommon.ipaddr('net') }}
+                   - to: {{ network | ansible.utils.ipaddr('net') }}
                      scope: link
                      table: 10{{ loop.index }}
               {% endfor -%}


### PR DESCRIPTION
ansible.netcommon.ipaddr was depreciated for ansible.utils.ipaddr.  This is causing some users to hit errors on ./nephele create. 

See similar issue here: https://github.com/ansible-collections/community.zabbix/issues/643