### PR TITLE
AWS: Subnet masks default for larger clusters

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -37,8 +37,8 @@ variable "subnet_cidr" {
     private = string
   })
   default     = {
-    public  = "10.0.100.0/24"
-    private = "10.0.200.0/24"
+    public  = "10.0.0.0/17"
+    private = "10.0.128.0/17"
   }
 }
 


### PR DESCRIPTION
`/24` subnets has only 254 unique IP addresses and nephele uses multiple IP addresses per node in the cluster imposing unnecessary restrictions on the supported cluster size.