### PR TITLE
Increase Timeout For AWS instances

### DIFF
--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -76,6 +76,7 @@ resource "aws_autoscaling_group" "default" {
   max_size            = var.replicas
   min_size            = var.replicas
   desired_capacity    = var.replicas
+  wait_for_capacity_timeout = "30m"
 
   launch_template {
     id      = aws_launch_template.default.id


### PR DESCRIPTION
The default waiting time is 10 minutes for waiting for compute instances to be launched. When launching large clusters this timeout will be hit just because of how long it takes for standup.  I am proposing increasing the default to 30 minutes to allow more time for the compute nodes to arrive.